### PR TITLE
fix(utils): Utils now use two version of fs

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,19 +1,44 @@
-const fs = require('fs-extra');
+const fs = require('fs');
+const fsExtra = require('fs-extra');
 
-const appendFile = (path, data) =>
-  fs.appendFile(path, `${data}\n`, { encoding: 'utf8' });
+const appendFile = (path, data) => {
+  return new Promise((resolve, reject) => {
+    fs.appendFile(path, `${data}\n`, { encoding: 'utf8' }, (err) => {
+      if (err) return reject(err);
+      return resolve();
+    });
+  });
+};
 
-const readFileSize = path =>
-  fs.stat(path).then(stat => stat.size);
+const readFileSize = (path) => {
+  return new Promise((resolve, reject) => {
+    fs.stat(path, (err, stat) => {
+      if (err) return reject(err);
+      return resolve(stat.size);
+    });
+  });
+};
 
-const readFile = path =>
-  fs.readFile(path, { encoding: 'utf8' });
+const readFile = (path) => {
+  return new Promise((resolve, reject) => {
+    fs.readFile(path, { encoding: 'utf8' }, (err, data) => {
+      if (err) return reject(err);
+      return resolve(data);
+    });
+  });
+};
 
-const deleteFile = path =>
-  fs.remove(path);
+const deleteFile = (path) => {
+  return new Promise((resolve, reject) => {
+    fs.unlink(path, (err) => {
+      if (err) return reject(err);
+      return resolve();
+    });
+  });
+};
 
 const copyFile = (source, target) =>
-  fs.copy(source, target);
+  fsExtra.copy(source, target);
 
 module.exports = {
   appendFile,


### PR DESCRIPTION
To make sure that it compatible with app that uses old version of `fs-extra` that does not have the
proper fs.appendFile, fs.stat, fs.readFile, and fs.unlink